### PR TITLE
feat(api): made the API safer to use and simpler to implement

### DIFF
--- a/api/src/main/scala/slog4s/ArgLogBuilder.scala
+++ b/api/src/main/scala/slog4s/ArgLogBuilder.scala
@@ -1,0 +1,52 @@
+package slog4s
+
+/**
+  * A part of logging API for a specific logging level. This trait is used to build a list
+  * of structured argument to be used for current logging statement.
+  *
+  * @tparam F
+  */
+trait ArgLogBuilder[F[_]] {
+
+  /**
+    * Log simple message with no exception.
+    * @param msg message to be logged
+    * @return
+    */
+  def log(msg: => String)(implicit location: Location): F[Unit]
+
+  /**
+    * Log simple message with an exception.
+    * @param msg message to be logged
+    * @param ex exception to be logged
+    * @return
+    */
+  def log(ex: Throwable, msg: => String)(implicit location: Location): F[Unit]
+
+  /**
+    * Extends current logging statement with structured data.
+    *
+    * @param key name of the argument
+    * @param value value to be used as structured argument
+    * @tparam T type of structured argument. It needs to implement [[LogEncoder]] typeclass.
+    * @return a new [[ArgLogBuilder]] instance containing provided structured argument
+    */
+  def withArg[T: LogEncoder](key: String, value: => T): ArgLogBuilder[F]
+}
+
+private[slog4s] class DeferredArgLogBuilder[F[_]](
+    whenEnabledLogBuilder: WhenEnabledLogBuilder[F]
+) extends ArgLogBuilder[F] {
+  override def log(msg: => String)(implicit location: Location): F[Unit] =
+    whenEnabledLogBuilder(_.log(msg))
+
+  override def log(ex: Throwable, msg: => String)(
+      implicit location: Location
+  ): F[Unit] = whenEnabledLogBuilder(_.log(ex, msg))
+
+  override def withArg[T: LogEncoder](
+      key: String,
+      value: => T
+  ): ArgLogBuilder[F] =
+    new DeferredArgLogBuilder(whenEnabledLogBuilder.withArg(key, value))
+}

--- a/api/src/main/scala/slog4s/WhenEnabledLogBuilder.scala
+++ b/api/src/main/scala/slog4s/WhenEnabledLogBuilder.scala
@@ -1,7 +1,7 @@
 package slog4s
 
-import cats.{Applicative, FlatMap}
 import cats.syntax.flatMap._
+import cats.{Applicative, FlatMap}
 
 /**
   * A part of logging API for a specific logging level. This trait is useful in case when

--- a/slf4j/src/main/scala/slog4s/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/slog4s/slf4j/Slf4jLogger.scala
@@ -25,25 +25,6 @@ private[slf4j] class Slf4jLogger[F[_]](
       doLog: DoLog,
       isLogEnabled: IsLogEnabled
   ) extends LevelLogBuilder[F] {
-    override def apply(msg: String)(implicit location: Location): F[Unit] =
-      self.log(doLog, isLogEnabled, Map.empty, msg, null, location)
-
-    override def apply(ex: Throwable, msg: String)(
-        implicit location: Location
-    ): F[Unit] =
-      self.log(doLog, isLogEnabled, Map.empty, msg, ex, location)
-
-    override def withArg[T: LogEncoder](
-        key: String,
-        value: => T
-    ): LogBuilder[F] = {
-      new Log(
-        Map(key -> (() => LogEncoder[T].encode(value))),
-        doLog,
-        isLogEnabled
-      )
-    }
-
     override def whenEnabled: WhenEnabledLogBuilder[F] =
       new WhenEnabled(isLogEnabled, new Log(Map.empty, doLog, isLogEnabled))
   }

--- a/testkit/src/main/scala/slog4s/testkit/MockLogger.scala
+++ b/testkit/src/main/scala/slog4s/testkit/MockLogger.scala
@@ -4,7 +4,6 @@ import java.io.PrintStream
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import cats.data.Chain
 import cats.effect.concurrent.Ref
 import cats.effect.{Clock, Sync}
 import cats.syntax.flatMap._
@@ -99,18 +98,6 @@ private class LogEventBuilder[F[_]: Monad: Clock](
 private class MockLevelLogBuilder[F[_]](
     logEventBuilder: LogEventBuilder[F]
 ) extends LevelLogBuilder[F] {
-  override def apply(msg: String)(implicit location: Location): F[Unit] =
-    logEventBuilder.make(msg, None, Map.empty)
-
-  override def apply(ex: Throwable, msg: String)(
-      implicit location: Location
-  ): F[Unit] = logEventBuilder.make(msg, Some(ex), Map.empty)
-
-  override def withArg[T: LogEncoder](key: String, value: => T): LogBuilder[F] =
-    new MockLogBuilder(
-      logEventBuilder,
-      Map(key -> LogEncoder[T].encode(value)(ArgumentStructureBuilder))
-    )
   override def whenEnabled: WhenEnabledLogBuilder[F] =
     new MockWhenEnabledLogBuilder(logEventBuilder)
 }


### PR DESCRIPTION
Commit messages says it all..I'm introducing a slight change to the API such it is safer to use by default. By that I mean a case when "expensive" string is passed a log message. We now pass it by name.

It also simplified all implementations.

The change is mostly source-compatible, but not binary-compatible. The only change that is not source compatible is related to the new `ArgLogBuilder` trait. It could in theory cause some compile issues, but only in some rare cases.